### PR TITLE
Update the model URL to use https

### DIFF
--- a/face_detection/dsfd/detect.py
+++ b/face_detection/dsfd/detect.py
@@ -8,7 +8,7 @@ from torch.hub import load_state_dict_from_url
 from ..base import Detector
 from ..build import DETECTOR_REGISTRY
 
-model_url = "http://folk.ntnu.no/haakohu/WIDERFace_DSFD_RES152.pth"
+model_url = "https://folk.ntnu.no/haakohu/WIDERFace_DSFD_RES152.pth"
 
 
 @DETECTOR_REGISTRY.register_module


### PR DESCRIPTION
This commit updates the model URL to use https instead of http. The reason is the build_detector method failed with urllib error saying that the http url responding with 308 which urllib can't handle. After checking deeper, turns out the http link is just redirected to https, therefore I just submit the PR to update the URL.

A better follow up would be allowing client / library user to override the URL by exposing it as parameter.

![messageImage_1618983660253](https://user-images.githubusercontent.com/12123712/115506465-d6b68c00-a2b5-11eb-9746-7d3992789ea3.jpg)
